### PR TITLE
Python 3 compatability

### DIFF
--- a/eight_puzzle_example.py
+++ b/eight_puzzle_example.py
@@ -161,10 +161,10 @@ def problem(verbose):
 
     plan = planner(problem, heuristic=manhattan_distance_heuristic, verbose=verbose)
     if plan is None:
-        print 'No Plan!'
+        print('No Plan!')
     else:
         for action in plan:
-            print action
+            print(action)
 
 if __name__ == '__main__':
     from optparse import OptionParser

--- a/missionaries_cannibals_example.py
+++ b/missionaries_cannibals_example.py
@@ -119,10 +119,10 @@ def problem(verbose):
 
     plan = planner(problem, verbose=verbose)
     if plan is None:
-        print 'No Plan!'
+        print('No Plan!')
     else:
         for action in plan:
-            print action
+            print(action)
 
 if __name__ == '__main__':
     from optparse import OptionParser

--- a/pyddl/__init__.py
+++ b/pyddl/__init__.py
@@ -1,2 +1,2 @@
-from pyddl import *
-from planner import *
+from .pyddl import *
+from .planner import *

--- a/pyddl/planner.py
+++ b/pyddl/planner.py
@@ -28,7 +28,7 @@ def planner(problem, heuristic=None, state0=None, goal=None,
     start = time()
     while True:
         if len(fringe) == 0:
-            if verbose: print 'States Explored: %d' % states_explored
+            if verbose: print('States Explored: %d' % states_explored)
             return None
 
         # Get node with minimum evaluation function from heap
@@ -40,9 +40,9 @@ def planner(problem, heuristic=None, state0=None, goal=None,
             plan = node.plan()
             dur = time() - start
             if verbose:
-                print 'States Explored: %d' % states_explored
-                print 'Time per state: %.3f ms' % (1000*dur / states_explored)
-                print 'Plan length: %d' % node.cost
+                print('States Explored: %d' % states_explored)
+                print('Time per state: %.3f ms' % (1000*dur / states_explored))
+                print('Plan length: %d' % node.cost)
             return plan
 
         # Expand node if we haven't seen it before

--- a/pyddl/pyddl.py
+++ b/pyddl/pyddl.py
@@ -129,6 +129,8 @@ class State(object):
     def __str__(self):
         return ('Predicates:\n%s' % '\n'.join(map(str, self.predicates))
                 +'\nFunctions:\n%s' % '\n'.join(map(str, self.functions)))
+    def __lt__(self, other):
+        return hash(self) < hash(other)
 
 def neg(effect):
     """


### PR DESCRIPTION
I've applied 2to3.py (excluding the "zip" and "dict" rules, which weren't necessary), and added a comparison operator to the State class, as required by heapq.
Both examples run OK for me now, but I haven't tested with Python 2.